### PR TITLE
fix:Fix the methods in misc.js may not be loaded

### DIFF
--- a/Resources/views/Form/froala_widget.html.twig
+++ b/Resources/views/Form/froala_widget.html.twig
@@ -2,6 +2,9 @@
 {% block froala_widget %}
 
 	{# JS. #}
+	{# misc.js #}
+	<script src="{{ asset( "bundles/kmsfroalaeditor/misc.js" ) }}"></script>
+
 	{% if includeJQuery %}
 		<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 	{% endif %}
@@ -12,7 +15,6 @@
 	{% endif %}
 
 	{% if includeJS %}
-		<script src="{{ asset( "bundles/kmsfroalaeditor/misc.js" ) }}"></script>
 		<script src="{{ asset( basePath ~ 'js/froala_editor.min.js' ) }}"></script>
 
 		<!--[if lt IE 9]>


### PR DESCRIPTION
If includeCodeMirror is not set to true, the methods named loadCSS and froalaDisplayError in misc.js can't be used below. 