### PR TITLE
Fix use of `class` - doesnt work on php < 5.5

### DIFF
--- a/Form/Type/FroalaEditorType.php
+++ b/Form/Type/FroalaEditorType.php
@@ -171,7 +171,7 @@
 
 			if( $this->m_version == 3 )
 			{
-				return TextareaType::class;
+				return "Symfony\Component\Form\Extension\Core\Type\TextareaType";
 			}
 
 			return "textarea";


### PR DESCRIPTION
The result is the same, but this works for older php