### PR TITLE
Change type hints from Router to RouterInterface

### DIFF
--- a/Service/OptionManager.php
+++ b/Service/OptionManager.php
@@ -2,7 +2,7 @@
 
 	namespace KMS\FroalaEditorBundle\Service;
 
-	use Symfony\Component\Routing\Router;
+	use Symfony\Component\Routing\RouterInterface;
 
 	/**
 	 * Class ParameterManager
@@ -16,7 +16,7 @@
 		// -------------------------------------------------------------//
 
 		/**
-		 * @var \Symfony\Component\Routing\Router
+		 * @var \Symfony\Component\Routing\RouterInterface
 		 */
 		private $m_router;
 
@@ -27,7 +27,7 @@
 		/**
 		 * Constructor.
 		 */
-		public function __construct( Router $p_router )
+		public function __construct( RouterInterface $p_router )
 		{
 			// ------------------------- DECLARE ---------------------------//
 


### PR DESCRIPTION
So you can use this with other routers, like the Symfony CMF's ChainRouter.