### PR TITLE
Allow for newer versions of Twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^5.3.3|^7.0",
         "symfony/framework-bundle": "^2.3|^3.0",
         "symfony/form": "^2.3|^3.0",
-        "twig/twig": "^1.1"
+        "twig/twig": "^1.1|^2.0"
     },
     "require-dev": {
         "symfony/twig-bundle": "^2.3|^3.0",


### PR DESCRIPTION
Newer versions of the Symfony Framework bundle (starting with 3.0.4: https://github.com/symfony/framework-bundle/blob/v3.0.4/composer.json) allow Twig 2.0 and higher (though SF 3.3 and such require 2.4 or higher).

So if you install Symfony, and then add this bundle later, it cannot be installed because you typically have Twig 2+ already installed, whereas this bundle currently specifies Twig 1.

While I am far from an expert, it does not look like there are any issues with this bundle as is running on Twig 2. I have been using it on Twig 2.4.3 on my local fork with no issues.