### PR TITLE
Possibility to define profiles (i.e. to define and use different froa…

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,7 +3,8 @@
 	namespace KMS\FroalaEditorBundle\DependencyInjection;
 
 	use KMS\FroalaEditorBundle\Utility\UConfiguration;
-	use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+    use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+    use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 	use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 	/**
@@ -38,13 +39,33 @@
 
 			// Add all available configuration nodes.
 			$nodeBuilder = $rootNode->addDefaultsIfNotSet()->children();
-			UConfiguration::addArrOptionBoolean( $nodeBuilder );
-			UConfiguration::addArrOptionInteger( $nodeBuilder );
-			UConfiguration::addArrOptionString( $nodeBuilder );
-			UConfiguration::addArrOptionArray( $nodeBuilder );
-			UConfiguration::addArrOptionObject( $nodeBuilder );
+			$this->addFroalaConfigTree( $nodeBuilder );
+			// "profiles" are treated separetely as they repeat main option structures
+			$profileSubTreeBuilder = $nodeBuilder
+              ->arrayNode('profiles')
+              ->useAttributeAsKey('name')
+              ->prototype('array')
+                    ->children();
+			$this->addFroalaConfigTree( $profileSubTreeBuilder , false );
+			$profileSubTreeBuilder->end()->end();
 			$nodeBuilder->end();
 
 			return $treeBuilder;
 		}
+
+        /**
+         * Add all options to configuration subtree
+         * 
+         * @param NodeBuilder $nodeBuilder
+         */
+		private function addFroalaConfigTree( & $nodeBuilder , $addDefaultValue = true )
+        {
+
+            UConfiguration::addArrOptionBoolean( $nodeBuilder , $addDefaultValue );
+            UConfiguration::addArrOptionInteger( $nodeBuilder , $addDefaultValue );
+            UConfiguration::addArrOptionString( $nodeBuilder, $addDefaultValue );
+            UConfiguration::addArrOptionArray( $nodeBuilder , $addDefaultValue );
+            UConfiguration::addArrOptionObject( $nodeBuilder , $addDefaultValue );
+
+        }
 	}

--- a/DependencyInjection/KMSFroalaEditorExtension.php
+++ b/DependencyInjection/KMSFroalaEditorExtension.php
@@ -58,21 +58,37 @@
 		 * @param array                                                   $p_arrConfig
 		 */
 		private function loadConfig( ContainerBuilder $p_container, array $p_arrConfig )
-		{
-			// ------------------------- DECLARE ---------------------------//
+        {
+            // ------------------------- DECLARE ---------------------------//
 
-			// Load defined options in config file.
-			foreach( UConfiguration::getArrOptionAll() as $option )
-			{
-				if( empty( $p_arrConfig [ $option ] ) == false || //
-					$p_arrConfig [ $option ] === false || //
-					$p_arrConfig [ $option ] === 0
-				)
-				{
-					$p_container->setParameter( Configuration::$NODE_ROOT . '.' . $option, $p_arrConfig [ $option ] );
-				}
+            // Load defined options in config file.
+            foreach (UConfiguration::getArrOptionAll() as $option) {
+                if (empty($p_arrConfig [$option]) == false || //
+                  $p_arrConfig [$option] === false || //
+                  $p_arrConfig [$option] === 0
+                ) {
+                    $p_container->setParameter(Configuration::$NODE_ROOT.'.'.$option, $p_arrConfig [$option]);
+                }
 
-			}
+            }
+
+            $parameterProfiles = array();
+
+            foreach ($p_arrConfig['profiles'] as $key => $profile) {
+                $parameterProfiles[$key] = array();
+                foreach ($profile as $optionKey => $optionValue) {
+                    if (empty($optionValue) == false || //
+                      $optionValue === false ||  //
+                      $optionValue === 0
+                    ) {
+                        $parameterProfiles[$key][$optionKey] = $optionValue;
+                    }
+                }
+            }
+
+            $p_container->setParameter(Configuration::$NODE_ROOT.'.profiles', $parameterProfiles);
+
+
 		}
 
 	}

--- a/Form/Type/FroalaEditorType.php
+++ b/Form/Type/FroalaEditorType.php
@@ -102,7 +102,23 @@
 			$arrOption         = array();
 			$arrPluginEnabled  = isset( $p_options [ "pluginsEnabled" ] ) ? $p_options [ "pluginsEnabled" ] : array();
 			$arrPluginDisabled = isset( $p_options [ "pluginsDisabled" ] ) ? $p_options [ "pluginsDisabled" ] : array();
+			$profile           = isset( $p_options [ "profile"] ) ? $p_options [ "profile" ] : null;
 			// ------------------------- DECLARE ---------------------------//
+
+            if ($profile && $this->m_container->hasParameter(Configuration::$NODE_ROOT . '.profiles'))
+            {
+
+                  $profiles = $this->m_container->getParameter(Configuration::$NODE_ROOT . '.profiles');
+
+                  if (array_key_exists($profile, $profiles))
+                  {
+                      $profileConfig = $profiles[$profile];
+                      $p_options = array_merge($p_options, $profileConfig);
+                  } else {
+                      throw new \Exception( 'Could not find profile "' . $profile . '", defined profiles: [' . join(',', $profiles ).']' );
+                  }
+
+            }
 
 			// Prepare options.
 			$this->m_optionManager->prepareOptions( $p_options );
@@ -122,7 +138,7 @@
 					}
 				}
 			}
-
+		
 			// Options.
 			$p_view->vars [ "arrOption" ] = $arrOption;
 
@@ -162,8 +178,11 @@
 				}
 			}
 
+
+            $arrDefined[] = 'profile';
 			$p_resolver->setDefined( $arrDefined );
 			$p_resolver->setDefaults( $arrDefault );
+
 		}
 
 		/**

--- a/Utility/UConfiguration.php
+++ b/Utility/UConfiguration.php
@@ -161,7 +161,7 @@
 			"fileUploadPath"    => null, //
 			"serialNumber"      => null, //
 			"videoUploadFolder" => "/upload", //
-			"videoUploadPath"   => null
+			"videoUploadPath"   => null,
 		);
 
 		public static $OPTIONS_ARRAY = array(
@@ -214,7 +214,7 @@
 		);
 
 		public static $OPTIONS_ARRAY_CUSTOM = array(
-			"pluginsDisabled" => array()
+			"pluginsDisabled" => array(),
 		);
 
 		public static $OPTIONS_OBJECT = array(
@@ -296,49 +296,71 @@
 
 		/**
 		 * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $p_nodeBuilder
+         * @param boolean
 		 */
-		public static function addArrOptionBoolean( NodeBuilder $p_nodeBuilder )
+		public static function addArrOptionBoolean( NodeBuilder $p_nodeBuilder, $addDefaultValue = true )
 		{
 			$array = array_merge( UConfiguration::$OPTIONS_BOOLEAN, UConfiguration::$OPTIONS_BOOLEAN_CUSTOM );
 			//------------------------- DECLARE ---------------------------//
 
 			foreach( $array as $option => $defaultValue )
 			{
-				$p_nodeBuilder = $p_nodeBuilder->booleanNode( $option )->defaultValue( $defaultValue )->end();
+				$p_nodeBuilder = $p_nodeBuilder->booleanNode( $option );
+				if ( $addDefaultValue )
+				{
+                    $p_nodeBuilder->defaultValue( $defaultValue );
+                }
+
+				$p_nodeBuilder = $p_nodeBuilder->end();
 			}
 		}
 
 		/**
 		 * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $p_nodeBuilder
+         * @param boolean
 		 */
-		public static function addArrOptionInteger( NodeBuilder $p_nodeBuilder )
+		public static function addArrOptionInteger( NodeBuilder $p_nodeBuilder, $addDefaultValue = true  )
 		{
 			//------------------------- DECLARE ---------------------------//
 
 			foreach( UConfiguration::$OPTIONS_INTEGER as $option => $defaultValue )
 			{
-				$p_nodeBuilder = $p_nodeBuilder->integerNode( $option )->defaultValue( $defaultValue )->end();
+				$p_nodeBuilder = $p_nodeBuilder->integerNode( $option );
+
+				if ($addDefaultValue)
+                {
+                    $p_nodeBuilder = $p_nodeBuilder->defaultValue( $defaultValue );
+                }
+
+				$p_nodeBuilder = $p_nodeBuilder->end();
 			}
 		}
 
 		/**
 		 * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $p_nodeBuilder
+         * @param boolean
 		 */
-		public static function addArrOptionString( NodeBuilder $p_nodeBuilder )
+		public static function addArrOptionString( NodeBuilder $p_nodeBuilder, $addDefaultValue = true )
 		{
 			$array = array_merge( UConfiguration::$OPTIONS_STRING, UConfiguration::$OPTIONS_STRING_CUSTOM );
 			//------------------------- DECLARE ---------------------------//
 
 			foreach( $array as $option => $defaultValue )
 			{
-				$p_nodeBuilder = $p_nodeBuilder->scalarNode( $option )->defaultValue( $defaultValue )->end();
+				$p_nodeBuilder = $p_nodeBuilder->scalarNode( $option );
+				if ($addDefaultValue)
+				{
+				    $p_nodeBuilder = $p_nodeBuilder->defaultValue( $defaultValue );
+				}
+				$p_nodeBuilder = $p_nodeBuilder->end();
 			}
 		}
 
 		/**
 		 * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $p_nodeBuilder
+         * @param boolean
 		 */
-		public static function addArrOptionArray( NodeBuilder $p_nodeBuilder )
+		public static function addArrOptionArray( NodeBuilder $p_nodeBuilder, $addDefaultValue = true )
 		{
 			$array = array_merge( UConfiguration::$OPTIONS_ARRAY, UConfiguration::$OPTIONS_ARRAY_CUSTOM );
 			//------------------------- DECLARE ---------------------------//
@@ -346,15 +368,22 @@
 			foreach( $array as $option => $defaultValue )
 			{
 				$p_nodeBuilder =
-					$p_nodeBuilder->arrayNode( $option )->prototype( 'variable' )->end()->defaultValue( $defaultValue )
-								  ->end();
+					$p_nodeBuilder->arrayNode( $option )->prototype( 'variable' )->end();
+
+				if ($addDefaultValue)
+                {
+                    $p_nodeBuilder = $p_nodeBuilder->defaultValue( $defaultValue );
+                }
+
+                $p_nodeBuilder = $p_nodeBuilder->end();
 			}
 		}
 
 		/**
 		 * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $p_nodeBuilder
+         * @param boolean
 		 */
-		public static function addArrOptionObject( NodeBuilder $p_nodeBuilder )
+		public static function addArrOptionObject( NodeBuilder $p_nodeBuilder, $addDefaultValue = true )
 		{
 			$array = array_merge( UConfiguration::$OPTIONS_OBJECT, UConfiguration::$OPTIONS_OBJECT_CUSTOM );
 			//------------------------- DECLARE ---------------------------//
@@ -362,8 +391,14 @@
 			foreach( $array as $option => $defaultValue )
 			{
 				$p_nodeBuilder =
-					$p_nodeBuilder->arrayNode( $option )->prototype( 'variable' )->end()->defaultValue( $defaultValue )
-								  ->end();
+					$p_nodeBuilder->arrayNode( $option )->prototype( 'variable' )->end();
+
+				if ($addDefaultValue)
+                {
+                    $p_nodeBuilder = $p_nodeBuilder->defaultValue( $defaultValue );
+                }
+
+                $p_nodeBuilder = $p_nodeBuilder->end();
 			}
 		}
 


### PR DESCRIPTION
Added a new configuration option "profiles" to define different configuration profiles for Froala (see @ #42 ).

I decided not to add this option as a "normal" neither "custom" option as it generates froala configuration subtrees that must also be validated., this added some complexity.

There is now also a new ```FroalaEditorType``` option defined which is "profile" through which one can specify the profile to use for the type. If the profile is not found amongst existing ones an exception is thrown.

The new configuration option does not break current configuration as requested, profiles just override "default" configurations.