### PR TITLE
Modifying the obtainFolder function to obtain a correct path under Symfony 4

### DIFF
--- a/Service/MediaManager.php
+++ b/Service/MediaManager.php
@@ -331,7 +331,7 @@
 			// ------------------------- DECLARE ---------------------------//
 
 			// TODO: use web directory specified by user if different.
-			return $p_rootDir . "/../web/" . $p_folder;
+			return $p_rootDir . "/../public/" . $p_folder;
 		}
 
 		/**


### PR DESCRIPTION
I realized that under Symfony 4 the image upload was still in the "web" folder and not in the "public" as the new SF4 architecture demanded.