### PR TITLE
Added IconsTemplate option support

### DIFF
--- a/Utility/UConfiguration.php
+++ b/Utility/UConfiguration.php
@@ -128,6 +128,7 @@
 			"fileUploadParam"          => null, //
 			"fileUploadURL"            => "kms_froala_editor_upload_file", //
 			"fontSizeUnit"             => null, //
+			"iconsTemplate"            => null, //
 			"iframeDefaultStyle"       => null, //
 			"iframeStyle"              => null, //
 			"imageCORSProxy"           => null, //


### PR DESCRIPTION
Hi,

I just added the "iconsTemplate" option support, so support for FontAwesome 5 can be added.  
Eg. if you want to enable it, just enter the following config in your YAML file:

```yaml
kms_froala_editor:
    iconsTemplate: 'font_awesome_5'
```