### PR TITLE
Public dir

### DIFF
--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -29,7 +29,7 @@
 			$path         = $p_request->request->get( "path" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
-            $publicDir    = $p_request->request->get("public_dir");
+			$publicDir    = $p_request->request->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 			// ------------------------- DECLARE ---------------------------//
 
@@ -51,7 +51,7 @@
 			$imageSrc     = $p_request->request->get( "src" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
-            $publicDir    = $p_request->request->get("public_dir");
+			$publicDir    = $p_request->request->get("public_dir");
 			// ------------------------- DECLARE ---------------------------//
 
 			$mediaManager->deleteImage( $imageSrc, $rootDir, $publicDir, $folder );
@@ -70,7 +70,7 @@
 			$path         = $p_request->query->get( "path" );
 			$folder       = $p_request->query->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
-            $publicDir    = $p_request->query->get("public_dir");
+			$publicDir    = $p_request->query->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 
 			// ------------------------- DECLARE ---------------------------//
@@ -89,7 +89,7 @@
 			$path         = $p_request->request->get( "path" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
-            $publicDir    = $p_request->request->get("public_dir");
+			$publicDir    = $p_request->request->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 			// ------------------------- DECLARE ---------------------------//
 
@@ -111,7 +111,7 @@
 			$path         = $p_request->request->get( "path" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
-            $publicDir    = $p_request->request->get("public_dir");
+			$publicDir    = $p_request->request->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 			// ------------------------- DECLARE ---------------------------//
 

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -29,13 +29,14 @@
 			$path         = $p_request->request->get( "path" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
+            $publicDir    = $p_request->request->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 			// ------------------------- DECLARE ---------------------------//
 
 			// FIXME
 //			if( $request->isXmlHttpRequest() == true )
 //			{
-				return $mediaManager->uploadImage( $p_request->files, $rootDir, $basePath, $folder, $path );
+				return $mediaManager->uploadImage( $p_request->files, $rootDir, $publicDir, $basePath, $folder, $path );
 //			}
 		}
 
@@ -50,9 +51,10 @@
 			$imageSrc     = $p_request->request->get( "src" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
+            $publicDir    = $p_request->request->get("public_dir");
 			// ------------------------- DECLARE ---------------------------//
 
-			$mediaManager->deleteImage( $imageSrc, $rootDir, $folder );
+			$mediaManager->deleteImage( $imageSrc, $rootDir, $publicDir, $folder );
 
 			return new Response ();
 		}
@@ -68,11 +70,12 @@
 			$path         = $p_request->query->get( "path" );
 			$folder       = $p_request->query->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
+            $publicDir    = $p_request->query->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 
 			// ------------------------- DECLARE ---------------------------//
 
-			return $mediaManager->loadImages( $rootDir, $basePath, $folder, $path );
+			return $mediaManager->loadImages( $rootDir, $publicDir, $basePath, $folder, $path );
 		}
 
 		/**
@@ -86,13 +89,14 @@
 			$path         = $p_request->request->get( "path" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
+            $publicDir    = $p_request->request->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 			// ------------------------- DECLARE ---------------------------//
 
 			// FIXME
 //			if( $request->isXmlHttpRequest() == true )
 //			{
-			return $mediaManager->uploadFile( $p_request->files, $rootDir, $basePath, $folder, $path );
+			return $mediaManager->uploadFile( $p_request->files, $rootDir, $publicDir, $basePath, $folder, $path );
 //			}
 		}
 
@@ -107,13 +111,14 @@
 			$path         = $p_request->request->get( "path" );
 			$folder       = $p_request->request->get( "folder" );
 			$rootDir      = $this->get( "kernel" )->getRootDir();
+            $publicDir    = $p_request->request->get("public_dir");
 			$basePath     = $p_request->getBasePath();
 			// ------------------------- DECLARE ---------------------------//
 
 			// FIXME
 //			if( $request->isXmlHttpRequest() == true )
 //			{
-			return $mediaManager->uploadVideo( $p_request->files, $rootDir, $basePath, $folder, $path );
+			return $mediaManager->uploadVideo( $p_request->files, $rootDir, $publicDir, $basePath, $folder, $path );
 //			}
 		}
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ kms_froala_editor:
   # Usage: if you are using URL rewritting for your assets.
   # Default: same value as provided as folder.
   fileUploadPath: "/my/upload/path"
+  
+  # Your public directory, from the root directory.
+  # Default: "/web"
+  publicDir: "/public"
 ```
 
 #### Concept: Autosave

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -19,6 +19,7 @@ services:
 # Media manager.
     kms_froala_editor.media_manager:
         class: "KMS\\FroalaEditorBundle\\Service\\MediaManager"
+        public: true
 
 # Twig extension.
     kms_froala_editor.froala_extension:

--- a/Service/MediaManager.php
+++ b/Service/MediaManager.php
@@ -38,13 +38,14 @@
 		 * Upload an image.
 		 * @param \Symfony\Component\HttpFoundation\FileBag $p_file
 		 * @param string                                    $p_rootDir
+		 * @param string                                    $p_publicDir
 		 * @param string                                    $p_basePath
 		 * @param string                                    $p_folder
 		 * @param string                                    $p_path
 		 * @return \Symfony\Component\HttpFoundation\JsonResponse
 		 * @throws \Exception
 		 */
-		public function uploadImage( FileBag $p_file, $p_rootDir, $p_basePath, $p_folder, $p_path )
+		public function uploadImage( FileBag $p_file, $p_rootDir, $p_publicDir, $p_basePath, $p_folder, $p_path )
 		{
 			$arrExtension = array(
 				"gif",
@@ -52,7 +53,7 @@
 				"jpg",
 				"png"
 			);
-			$folder       = $this->obtainFolder( $p_rootDir, $p_folder );
+			$folder       = $this->obtainFolder( $p_rootDir, $p_publicDir, $p_folder );
 			$path         = $this->obtainPath( $p_basePath, $p_path );
 			$response     = new JsonResponse ();
 			// ------------------------- DECLARE ---------------------------//
@@ -121,11 +122,12 @@
 		 * Delete an image.
 		 * @param string $p_imageSrc
 		 * @param string $p_rootDir
+		 * @param string $p_publicDir
 		 * @param string $p_folder
 		 */
-		public function deleteImage( $p_imageSrc, $p_rootDir, $p_folder )
+		public function deleteImage( $p_imageSrc, $p_rootDir, $p_publicDir, $p_folder )
 		{
-			$folder      = $this->obtainFolder( $p_rootDir, $p_folder );
+			$folder      = $this->obtainFolder( $p_rootDir, $p_publicDir, $p_folder );
 			$arrExploded = explode( '/', $p_imageSrc );
 			// ------------------------- DECLARE ---------------------------//
 
@@ -136,17 +138,18 @@
 		/**
 		 * Load images.
 		 * @param string $p_rootDir
+		 * @param string $p_publicDir
 		 * @param string $p_basePath
 		 * @param string $p_folder
 		 * @param string $p_path
 		 * @return \Symfony\Component\HttpFoundation\JsonResponse
 		 * @throws \Exception
 		 */
-		public function loadImages( $p_rootDir, $p_basePath, $p_folder, $p_path )
+		public function loadImages( $p_rootDir, $p_publicDir, $p_basePath, $p_folder, $p_path )
 		{
 			$response     = new JsonResponse ();
 			$arrImage     = array();
-			$folder       = $this->obtainFolder( $p_rootDir, $p_folder );
+			$folder       = $this->obtainFolder( $p_rootDir, $p_publicDir, $p_folder );
 			$path         = $this->obtainPath( $p_basePath, $p_path );
 			$finder       = new Finder ();
 			$arrExtension = array(
@@ -178,15 +181,16 @@
 		 * Upload an image.
 		 * @param \Symfony\Component\HttpFoundation\FileBag $p_file
 		 * @param string                                    $p_rootDir
+		 * @param string                                    $p_publicDir
 		 * @param string                                    $p_basePath
 		 * @param string                                    $p_folder
 		 * @param string                                    $p_path
 		 * @return \Symfony\Component\HttpFoundation\JsonResponse
 		 * @throws \Exception
 		 */
-		public function uploadFile( FileBag $p_file, $p_rootDir, $p_basePath, $p_folder, $p_path )
+		public function uploadFile( FileBag $p_file, $p_rootDir, $p_publicDir, $p_basePath, $p_folder, $p_path )
 		{
-			$folder   = $this->obtainFolder( $p_rootDir, $p_folder );
+			$folder   = $this->obtainFolder( $p_rootDir, $p_publicDir, $p_folder );
 			$path     = $this->obtainPath( $p_basePath, $p_path );
 			$response = new JsonResponse ();
 			// ------------------------- DECLARE ---------------------------//
@@ -237,13 +241,14 @@
 		 * Upload a video.
 		 * @param \Symfony\Component\HttpFoundation\FileBag $p_file
 		 * @param string                                    $p_rootDir
+		 * @param string                                    $p_publicDir
 		 * @param string                                    $p_basePath
 		 * @param string                                    $p_folder
 		 * @param string                                    $p_path
 		 * @return \Symfony\Component\HttpFoundation\JsonResponse
 		 * @throws \Exception
 		 */
-		public function uploadVideo( FileBag $p_file, $p_rootDir, $p_basePath, $p_folder, $p_path )
+		public function uploadVideo( FileBag $p_file, $p_rootDir, $p_publicDir, $p_basePath, $p_folder, $p_path )
 		{
 //			$arrExtension = array(
 //				"gif",
@@ -251,7 +256,7 @@
 //				"jpg",
 //				"png"
 //			);
-			$folder   = $this->obtainFolder( $p_rootDir, $p_folder );
+			$folder   = $this->obtainFolder( $p_rootDir, $p_publicDir, $p_folder );
 			$path     = $this->obtainPath( $p_basePath, $p_path );
 			$response = new JsonResponse ();
 			// ------------------------- DECLARE ---------------------------//
@@ -323,15 +328,15 @@
 		/**
 		 * Obtain the physical folder.
 		 * @param string $p_rootDir
+		 * @param string $p_publicDir
 		 * @param string $p_folder
 		 * @return string
 		 */
-		private function obtainFolder( $p_rootDir, $p_folder )
+		private function obtainFolder( $p_rootDir, $p_publicDir, $p_folder )
 		{
 			// ------------------------- DECLARE ---------------------------//
 
-			// TODO: use web directory specified by user if different.
-			return $p_rootDir . "/../web/" . $p_folder;
+            return sprintf('%s/..%s/%s', $p_rootDir, $p_publicDir, $p_folder);
 		}
 
 		/**

--- a/Service/MediaManager.php
+++ b/Service/MediaManager.php
@@ -336,7 +336,7 @@
 		{
 			// ------------------------- DECLARE ---------------------------//
 
-            return sprintf('%s/..%s/%s', $p_rootDir, $p_publicDir, $p_folder);
+			return sprintf('%s/..%s/%s', $p_rootDir, $p_publicDir, $p_folder);
 		}
 
 		/**

--- a/Service/OptionManager.php
+++ b/Service/OptionManager.php
@@ -191,7 +191,7 @@
 			$imageManagerDeleteParams =
 				isset( $p_arrOption[ "imageManagerDeleteParams" ] ) ? $p_arrOption[ "imageManagerDeleteParams" ] : array();
 			$arrCustomParams          =
-				array( "folder" => $p_arrOption[ "imageUploadFolder" ], "path" => $p_arrOption[ "imageUploadPath" ] );
+				array( "folder" => $p_arrOption[ "imageUploadFolder" ], "path" => $p_arrOption[ "imageUploadPath" ], "public_dir" => $p_arrOption[ "publicDir" ] );
 			//------------------------- DECLARE ---------------------------//
 
 			$p_arrOption[ "imageUploadParams" ]        = array_merge( $imageUploadParams, $arrCustomParams );
@@ -208,7 +208,7 @@
 			$fileUploadParams =
 				isset( $p_arrOption[ "fileUploadParams" ] ) ? $p_arrOption[ "fileUploadParams" ] : array();
 			$arrCustomParams  =
-				array( "folder" => $p_arrOption[ "fileUploadFolder" ], "path" => $p_arrOption[ "fileUploadPath" ] );
+				array( "folder" => $p_arrOption[ "fileUploadFolder" ], "path" => $p_arrOption[ "fileUploadPath" ], "public_dir" => $p_arrOption[ "publicDir" ] );
 			//------------------------- DECLARE ---------------------------//
 
 			$p_arrOption[ "fileUploadParams" ] = array_merge( $fileUploadParams, $arrCustomParams );
@@ -223,7 +223,7 @@
 			$videoUploadParams =
 				isset( $p_arrOption[ "videoUploadParams" ] ) ? $p_arrOption[ "videoUploadParams" ] : array();
 			$arrCustomParams   =
-				array( "folder" => $p_arrOption[ "videoUploadFolder" ], "path" => $p_arrOption[ "videoUploadPath" ] );
+				array( "folder" => $p_arrOption[ "videoUploadFolder" ], "path" => $p_arrOption[ "videoUploadPath" ], "public_dir" => $p_arrOption[ "publicDir" ] );
 			//------------------------- DECLARE ---------------------------//
 
 			$p_arrOption[ "videoUploadParams" ] = array_merge( $videoUploadParams, $arrCustomParams );

--- a/Utility/UConfiguration.php
+++ b/Utility/UConfiguration.php
@@ -169,7 +169,7 @@
 			"serialNumber"      => null, //
 			"videoUploadFolder" => "/upload", //
 			"videoUploadPath"   => null,
-            "publicDir"         => "/web",
+			"publicDir"         => "/web",
 		);
 
 		public static $OPTIONS_ARRAY = array(

--- a/Utility/UConfiguration.php
+++ b/Utility/UConfiguration.php
@@ -169,6 +169,7 @@
 			"serialNumber"      => null, //
 			"videoUploadFolder" => "/upload", //
 			"videoUploadPath"   => null,
+            "publicDir"         => "/web",
 		);
 
 		public static $OPTIONS_ARRAY = array(


### PR DESCRIPTION
Hi,

I propose this pull request to fix some stuff using Symfony 4 (or earlier, depends on your configuration).

It is an alternative to #52, which doesn't make the directory configurable.

This PR fixes two issues:

- Make the MediaManager public, so the MediaController does not fail anymore (fixes #54)
- Allow configuring the public directory, using `publicDir` config key. I kept `/web` as default to maintain backward compatibility.

I know I could also inject the MediaManager into the MediaController in an other way, but then I would feel forced to update the entire bundle ;)