### PR TITLE
Fix for unwanted parameters when using imageUploadToS3

### DIFF
--- a/Service/OptionManager.php
+++ b/Service/OptionManager.php
@@ -194,7 +194,10 @@
 				array( "folder" => $p_arrOption[ "imageUploadFolder" ], "path" => $p_arrOption[ "imageUploadPath" ], "public_dir" => $p_arrOption[ "publicDir" ] );
 			//------------------------- DECLARE ---------------------------//
 
-			$p_arrOption[ "imageUploadParams" ]        = array_merge( $imageUploadParams, $arrCustomParams );
+            //Always adding these params breaks s3 signing in some cases
+            if (!array_key_exists('imageUploadToS3', $p_arrOption)) {
+                $p_arrOption[ "imageUploadParams" ]        = array_merge( $imageUploadParams, $arrCustomParams );
+            }
 			$p_arrOption[ "imageManagerLoadParams" ]   = array_merge( $imageManagerLoadParams, $arrCustomParams );
 			$p_arrOption[ "imageManagerDeleteParams" ] = array_merge( $imageManagerDeleteParams, $arrCustomParams );
 		}


### PR DESCRIPTION
This is a small change to exclude the default `imageUploadParams` params when using [imageUploadToS3](https://www.froala.com/wysiwyg-editor/docs/options#imageUploadToS3). Having the parameters there can cause issues with signing.