### PR TITLE
Doctrine inflector upgrade

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -1,6 +1,13 @@
 CHANGELOG FOR 3.X
 =================
 
+3.1.0
+-----
+
+* Minimum PHP version set to 7.2
+* Upgraded `doctrine/inflector` requirement from `^1.3` to `^1.4|2.0` to fix deprecations
+* Added first test
+
 3.0.3
 -----
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The changelog is available here: [CHANGELOG-3.x.md](CHANGELOG-3.x.md).
 
 ## Migration to Froala Editor bundle v3 from v2
 
-The Froala Editor bundle got a major upgrade from v2 to v3. It now supports only Symfony 4.3+ and requires PHP 7.1.3+.
+The Froala Editor bundle got a major upgrade from v2 to v3. It now supports only Symfony 4.3+ and requires PHP 7.2+.
 
 As the static files are no longer included (so you don't have to upgrade this bundle for each Froala release) you can
 import assets the way you need (using the install command described below or eg. from your public directory).

--- a/Service/PluginProvider.php
+++ b/Service/PluginProvider.php
@@ -2,7 +2,10 @@
 
 	namespace KMS\FroalaEditorBundle\Service;
 
-	use Doctrine\Common\Inflector\Inflector;
+	use Doctrine\Inflector\CachedWordInflector;
+    use Doctrine\Inflector\Inflector;
+    use Doctrine\Inflector\RulesetInflector;
+    use Doctrine\Inflector\Rules\English;
 
 	/**
 	 * Class PluginProvider
@@ -70,6 +73,11 @@
 		private static $ARR_THIRD_PARTY_CONFIG =
 			array();
 
+        /**
+         * @var Inflector
+         */
+		protected $inflector;
+
 		/**
 		 * @const string
 		 */
@@ -97,8 +105,15 @@
 		 */
 		public function __construct()
 		{
-			//------------------------- DECLARE ---------------------------//
-		}
+            $this->inflector = new Inflector(
+                new CachedWordInflector(new RulesetInflector(
+                    English\Rules::getSingularRuleset()
+                )),
+                new CachedWordInflector(new RulesetInflector(
+                    English\Rules::getPluralRuleset()
+                ))
+            );
+        }
 
 		//-------------------------------------------------------------//
 		//--------------------------- METHODS -------------------------//
@@ -180,7 +195,7 @@
 
 			foreach( $p_arrPlugin as $plugin )
 			{
-				$arrPlugin[] = Inflector::camelize( $plugin );
+				$arrPlugin[] = $this->inflector->camelize( $plugin );
 			}
 
 			return $arrPlugin;

--- a/Tests/Service/PluginProviderTest.php
+++ b/Tests/Service/PluginProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KMS\FroalaEditorBundle\Tests\Service;
+
+use KMS\FroalaEditorBundle\Service\PluginProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PluginProviderTest extends TestCase
+{
+    /**
+     * @var PluginProvider
+     */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new PluginProvider();
+    }
+
+    public function testObtainArrPluginCamelized(): void
+    {
+        static::assertSame(['paragraphFormat'], $this->provider->obtainArrPluginCamelized(['paragraph_format']));
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-zip": "*",
-        "doctrine/inflector": "^1.3",
+        "doctrine/inflector": "^1.4|^2.0",
         "symfony/console": "^4.3|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/form": "^4.3|^5.0",
@@ -26,6 +26,7 @@
         "twig/twig": "^1.1|^2.0|^3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^9.1",
         "symfony/yaml": "^4.3|^5.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+    bootstrap="Tests/bootstrap.php"
+>
+    <testsuites>
+        <testsuite name="KMSFroalaEditorBundle Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Hi,

I created this PR to fix recent deprecations with doctrine/inflector 1.4.x and to allow the 2.0 version.

I also added a test to check the function in PluginProvider works the same as before (tested locally using 1.4 & 2.0 versions).

I had to upgrade the min PHP version to 7.2 as both 1.4 & 2.0 versions of the inflector made the move. I think it's not a problem as [PHP 7.1 is not supported anymore](https://www.php.net/supported-versions).

When releasing/tagging, you should create a 3.1.0 version/tag and not 3.0.4 as the dependency bumps should not be a patch upgrade.