### PR TITLE
Enhancement/custom js array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,14 @@ kms_froala_editor:
     # Defaults to "/bundles/kmsfroalaeditor/froala_editor"
     basePath: "/my/custom/path".
 
-    # Custom JS file.
-    # Usage: add custom plugins/buttons...
-    customJS: "/custom/js/path"
-```
+    # Custom JS file(s).
+    # Usage: add custom plugins/buttons.
+    # To load a single custom JavaScript file:
+    customJS: "/path/to/custom/script.js"
+    # To load multiple custom JavaScript files:
+    customJS:
+    - "/path/to/custom/script1.js"
+    - "/path/to/custom/script2.js"
 
 ### Step 6: Add Froala to your form
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 This bundle aims to easily integrate & use the Froala editor in Symfony 4.4+/5.0+.
 
+It also supports PHP 7.4.
+
 If you want to use it with Symfony < 4.3, see [v2 docs](https://github.com/froala/KMSFroalaEditorBundle/tree/v2).
 v2.x is compatible with Symfony 2.x to 4.x, but some deprecations are not fixed and static files are integrated to the
 bundle.

--- a/src/Resources/views/Form/froala_widget.html.twig
+++ b/src/Resources/views/Form/froala_widget.html.twig
@@ -48,7 +48,13 @@
     {% endif %}
 
     {% if froala_customJS is defined %}
-        <script type="text/javascript"  src="{{ asset( customJS ) }}"></script>
+        {% if froala_customJS is iterable %}
+            {% for script in froala_customJS %}
+                <script type="text/javascript" src="{{ asset(script) }}"></script>
+            {% endfor %}
+        {% else %}
+            <script type="text/javascript" src="{{ asset(froala_customJS) }}"></script>
+        {% endif %}
     {% endif %}
 
     {# Load the editor. #}


### PR DESCRIPTION
This change implements the fix for #134 by refactoring the customJS option to support both a single string or an array of strings specifying the custom script path(s) while maintaining backwards compatibility.